### PR TITLE
replace old OpenAPI models with *_Input imports

### DIFF
--- a/frontend/src/api/models/Address.ts
+++ b/frontend/src/api/models/Address.ts
@@ -1,2 +1,0 @@
-export type { Address_Input as Address } from './Address_Input';
-export { Address_InputRequired as AddressRequired } from './Address_Input';

--- a/frontend/src/api/models/AiModel.ts
+++ b/frontend/src/api/models/AiModel.ts
@@ -1,2 +1,0 @@
-export type { AiModel_Input as AiModel } from './AiModel_Input';
-export { AiModel_InputRequired as AiModelRequired } from './AiModel_Input';

--- a/frontend/src/api/models/Client.ts
+++ b/frontend/src/api/models/Client.ts
@@ -1,2 +1,0 @@
-export type { Client_Input as Client } from './Client_Input';
-export { Client_InputRequired as ClientRequired } from './Client_Input';

--- a/frontend/src/api/models/Contact.ts
+++ b/frontend/src/api/models/Contact.ts
@@ -1,2 +1,0 @@
-export type { Contact_Input as Contact } from './Contact_Input';
-export { Contact_InputRequired as ContactRequired } from './Contact_Input';

--- a/frontend/src/api/models/OrganizationResponse.ts
+++ b/frontend/src/api/models/OrganizationResponse.ts
@@ -7,7 +7,7 @@ export type OrganizationResponse = {
     name: string;
     code: string;
     description?: (string | null);
-    status: string;
+    status?: string;
     tier_id?: (string | null);
     local_only_conversations?: boolean;
 };

--- a/frontend/src/api/models/Project.ts
+++ b/frontend/src/api/models/Project.ts
@@ -1,2 +1,0 @@
-export type { Project_Input as Project } from './Project_Input';
-export { Project_InputRequired as ProjectRequired } from './Project_Input';

--- a/frontend/src/api/models/ProjectDocument.ts
+++ b/frontend/src/api/models/ProjectDocument.ts
@@ -1,2 +1,0 @@
-export type { ProjectDocument_Input as ProjectDocument } from './ProjectDocument_Input';
-export { ProjectDocument_InputRequired as ProjectDocumentRequired } from './ProjectDocument_Input';

--- a/frontend/src/api/models/Tier.ts
+++ b/frontend/src/api/models/Tier.ts
@@ -1,2 +1,0 @@
-export type { Tier_Input as Tier } from './Tier_Input';
-export { Tier_InputRequired as TierRequired } from './Tier_Input';

--- a/frontend/src/app/(admin)/(entities)/addresses/page.tsx
+++ b/frontend/src/app/(admin)/(entities)/addresses/page.tsx
@@ -14,7 +14,7 @@ import { useTailwindMuiTheme } from "@/app/lib/util";
 import { getApiErrorInfo } from "@/app/lib/api-error";
 
 import { AddressesService } from "@/api/services/AddressesService";
-import type { Address } from "@/api/models/Address";
+import type { Address_Input as Address } from "@/api/models/Address_Input";
 
 import AddressGrid from "@/components/entity/address/AddressGrid";
 import AddressDetailView from "@/components/entity/address/AddressDetailView";

--- a/frontend/src/app/(admin)/(entities)/aimodels/page.tsx
+++ b/frontend/src/app/(admin)/(entities)/aimodels/page.tsx
@@ -14,7 +14,7 @@ import { useTailwindMuiTheme } from "@/app/lib/util";
 
 import useUserRole from "@/hooks/useUserRole";
 import { AiModelsService } from "@/api/services/AiModelsService";
-import type { AiModel } from "@/api/models/AiModel";
+import type { AiModel_Input as AiModel } from "@/api/models/AiModel_Input";
 
 import AiModelGrid from "@/components/entity/aimodel/AiModelGrid";
 import AiModelDetailView from "@/components/entity/aimodel/AiModelDetailView";

--- a/frontend/src/app/(admin)/(entities)/clients/page.tsx
+++ b/frontend/src/app/(admin)/(entities)/clients/page.tsx
@@ -17,9 +17,9 @@ import { ClientsService } from "@/api/services/ClientsService";
 import { ContactsService } from "@/api/services/ContactsService";
 import { AddressesService } from "@/api/services/AddressesService";
 import { ClientType } from "@/api/models/ClientType";
-import type { Client } from "@/api/models/Client";
-import type { Contact } from "@/api/models/Contact";
-import type { Address } from "@/api/models/Address";
+import type { Client_Input as Client } from "@/api/models/Client_Input";
+import type { Contact_Input as Contact } from "@/api/models/Contact_Input";
+import type { Address_Input as Address } from "@/api/models/Address_Input";
 
 import ClientGrid from "@/components/entity/client/ClientGrid";
 import ClientEditView from "@/components/entity/client/ClientEditView";

--- a/frontend/src/app/(admin)/(entities)/contacts/page.tsx
+++ b/frontend/src/app/(admin)/(entities)/contacts/page.tsx
@@ -14,7 +14,7 @@ import { useTailwindMuiTheme } from "@/app/lib/util";
 import { getApiErrorInfo } from "@/app/lib/api-error";
 
 import { ContactsService } from "@/api/services/ContactsService";
-import type { Contact } from "@/api/models/Contact";
+import type { Contact_Input as Contact } from "@/api/models/Contact_Input";
 
 import ContactGrid from "@/components/entity/contact/ContactGrid";
 import ContactDetailView from "@/components/entity/contact/ContactDetailView";

--- a/frontend/src/app/(admin)/(entities)/documents/page.tsx
+++ b/frontend/src/app/(admin)/(entities)/documents/page.tsx
@@ -14,7 +14,7 @@ import { useTailwindMuiTheme } from "@/app/lib/util";
 import { getApiErrorInfo } from "@/app/lib/api-error";
 
 import { DocumentsService } from "@/api/services/DocumentsService";
-import type { ProjectDocument } from "@/api/models/ProjectDocument";
+import type { ProjectDocument_Input as ProjectDocument } from "@/api/models/ProjectDocument_Input";
 
 import DocumentGrid from "@/components/entity/document/DocumentGrid";
 import DocumentDetailView from "@/components/entity/document/DocumentDetailView";

--- a/frontend/src/app/(admin)/(entities)/projects/page.tsx
+++ b/frontend/src/app/(admin)/(entities)/projects/page.tsx
@@ -14,7 +14,7 @@ import { useTailwindMuiTheme } from "@/app/lib/util";
 import { getApiErrorInfo } from "@/app/lib/api-error";
 
 import { ProjectsService } from "@/api/services/ProjectsService";
-import type { Project } from "@/api/models/Project";
+import type { Project_Input as Project } from "@/api/models/Project_Input";
 
 import ProjectGrid from "@/components/entity/project/ProjectGrid";
 import ProjectDetailView from "@/components/entity/project/ProjectDetailView";

--- a/frontend/src/app/(admin)/(entities)/tiers/page.tsx
+++ b/frontend/src/app/(admin)/(entities)/tiers/page.tsx
@@ -14,7 +14,7 @@ import { useTailwindMuiTheme } from "@/app/lib/util";
 
 import useUserRole from "@/hooks/useUserRole";
 import { TiersService } from "@/api/services/TiersService";
-import type { Tier } from "@/api/models/Tier";
+import type { Tier_Input as Tier } from "@/api/models/Tier_Input";
 
 import TierGrid from "@/components/entity/tier/TierGrid";
 import TierDetailView from "@/components/entity/tier/TierDetailView";

--- a/frontend/src/app/(admin)/(others-pages)/ai-assistant/components/ChatHeader.tsx
+++ b/frontend/src/app/(admin)/(others-pages)/ai-assistant/components/ChatHeader.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { EyeSlashIcon, PlusIcon, LightBulbIcon } from "@heroicons/react/24/outline";
-import { AiModel } from "@/api/models/AiModel";
+import { AiModel_Input as AiModel } from "@/api/models/AiModel_Input";
 import { ConversationHistory } from "./ConversationHistory";
 import { ModelSelect } from "./ModelSelect";
 import type { LocalConversation } from "@/db/conversationsDb";

--- a/frontend/src/app/(admin)/(others-pages)/ai-assistant/components/ChatInput.tsx
+++ b/frontend/src/app/(admin)/(others-pages)/ai-assistant/components/ChatInput.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect, useImperativeHandle, forwardRef, useCallback } from "react";
 import toast from "react-hot-toast";
 import { imageToBase64 } from "../utils/imageUtils";
-import { AiModel } from "@/api/models/AiModel";
+import { AiModel_Input as AiModel } from "@/api/models/AiModel_Input";
 import useSpeechToText from "@/hooks/useSpeechRecognition";
 
 interface ChatInputProps {

--- a/frontend/src/app/(admin)/(others-pages)/ai-assistant/hooks/useAiModels.ts
+++ b/frontend/src/app/(admin)/(others-pages)/ai-assistant/hooks/useAiModels.ts
@@ -2,7 +2,7 @@
 import { useState, useEffect, useRef } from "react";
 import toast from "react-hot-toast";
 import { AiModelsService } from "@/api/services/AiModelsService";
-import { AiModel } from "@/api/models/AiModel";
+import { AiModel_Input as AiModel } from "@/api/models/AiModel_Input";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { isModelAccessible } from "../components/ModelSelect";
 

--- a/frontend/src/app/(admin)/(others-pages)/ai-assistant/hooks/useChatStream.ts
+++ b/frontend/src/app/(admin)/(others-pages)/ai-assistant/hooks/useChatStream.ts
@@ -1,7 +1,7 @@
 // app/(admin)/(others-pages)/ai-assistant/hooks/useChatStream.ts
 import { useState, useRef, useCallback } from "react";
 import toast from "react-hot-toast";
-import { AiModel } from "@/api/models/AiModel";
+import { AiModel_Input as AiModel } from "@/api/models/AiModel_Input";
 import { conversationStorage } from "@/db/conversationStorage";
 import type { LocalConversation, Message } from "@/db/conversationsDb";
 import { syncConversationToServer } from "../utils/serverSync";

--- a/frontend/src/components/entity/address/AddressDetailView.tsx
+++ b/frontend/src/components/entity/address/AddressDetailView.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { EntityDetailView } from "@/components/entity/EntityDetailView";
-import type { Address } from "@/api/models/Address";
+import type { Address_Input as Address } from "@/api/models/Address_Input";
 
 export const detailFields: { 
   label: string; 

--- a/frontend/src/components/entity/address/AddressEditView.tsx
+++ b/frontend/src/components/entity/address/AddressEditView.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { EntityEditView } from "@/components/entity/EntityEditView";
-import { Address, AddressRequired } from "@/api/models/Address";
+import { Address_Input as Address, Address_InputRequired as AddressRequired } from "@/api/models/Address_Input";
 import {applyRequiredFlags} from "@/app/lib/type-utils";
 
 const baseFields = [

--- a/frontend/src/components/entity/address/AddressGrid.tsx
+++ b/frontend/src/components/entity/address/AddressGrid.tsx
@@ -2,7 +2,7 @@
 
 import { GridColDef } from "@mui/x-data-grid";
 import { EntityGrid } from "@/components/entity/EntityGrid";
-import type { Address } from "@/api/models/Address";
+import type { Address_Input as Address } from "@/api/models/Address_Input";
 
 const addressColumns: GridColDef[] = [
   { field: "street", headerName: "Street", flex: 1, minWidth: 150 },

--- a/frontend/src/components/entity/aimodel/AiModelDetailView.tsx
+++ b/frontend/src/components/entity/aimodel/AiModelDetailView.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { EntityDetailView } from "@/components/entity/EntityDetailView";
 import { formatEnum, formatDateTime } from "@/app/lib/util";
-import type { AiModel } from "@/api/models/AiModel";
+import type { AiModel_Input as AiModel } from "@/api/models/AiModel_Input";
 
 export const detailFields: {
   label: string;

--- a/frontend/src/components/entity/aimodel/AiModelEditView.tsx
+++ b/frontend/src/components/entity/aimodel/AiModelEditView.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { EntityEditView } from "@/components/entity/EntityEditView";
 import { formatEnum } from "@/app/lib/util";
-import type { AiModel } from "@/api/models/AiModel";
+import type { AiModel_Input as AiModel } from "@/api/models/AiModel_Input";
 import { AiServiceProvider } from "@/api/models/AiServiceProvider";
 
 interface AiModelEditViewProps {

--- a/frontend/src/components/entity/aimodel/AiModelGrid.tsx
+++ b/frontend/src/components/entity/aimodel/AiModelGrid.tsx
@@ -3,7 +3,7 @@
 "use client";
 import { GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import { EntityGrid } from "@/components/entity/EntityGrid";
-import type { AiModel } from "@/api/models/AiModel";
+import type { AiModel_Input as AiModel } from "@/api/models/AiModel_Input";
 import { formatEnum } from "@/app/lib/util";
 
 interface AiModelGridProps {

--- a/frontend/src/components/entity/client/ClientDetailExtras.tsx
+++ b/frontend/src/components/entity/client/ClientDetailExtras.tsx
@@ -10,10 +10,10 @@ import { ProjectsService } from "@/api/services/ProjectsService";
 import { useProjectReferenceField } from "@/hooks/useProjectReferenceField";
 import { usePaginatedEntityList } from "@/hooks/usePaginatedEntityList";
 
-import type { Client } from "@/api/models/Client";
-import type { Contact } from "@/api/models/Contact";
-import type { Address } from "@/api/models/Address";
-import type { Project } from "@/api/models/Project";
+import type { Client_Input as Client } from "@/api/models/Client_Input";
+import type { Contact_Input as Contact } from "@/api/models/Contact_Input";
+import type { Address_Input as Address } from "@/api/models/Address_Input";
+import type { Project_Input as Project } from "@/api/models/Project_Input";
 import ProjectEditView from "../project/ProjectEditView";
 import { Modal } from "@/components/ui/modal";
 import Button from "@/components/ui/button/Button";

--- a/frontend/src/components/entity/client/ClientDetailView.tsx
+++ b/frontend/src/components/entity/client/ClientDetailView.tsx
@@ -2,7 +2,7 @@
 "use client";
 import React from "react";
 import { EntityDetailView } from "@/components/entity/EntityDetailView";
-import type { Client } from "@/api/models/Client";
+import type { Client_Input as Client } from "@/api/models/Client_Input";
 import { formatEnum } from "@/app/lib/util";
 
 export const detailFields: {

--- a/frontend/src/components/entity/client/ClientEditView.tsx
+++ b/frontend/src/components/entity/client/ClientEditView.tsx
@@ -1,7 +1,7 @@
 // components/entity/client/ClientEditView.tsx
 import React from "react";
 import { EntityEditView } from "@/components/entity/EntityEditView";
-import { Client, ClientRequired } from "@/api/models/Client";
+import { Client_Input as Client, Client_InputRequired as ClientRequired } from "@/api/models/Client_Input";
 import { ClientType } from "@/api/models/ClientType";
 import { formatEnum } from "@/app/lib/util";
 import {applyRequiredFlags} from "@/app/lib/type-utils";

--- a/frontend/src/components/entity/client/ClientGrid.tsx
+++ b/frontend/src/components/entity/client/ClientGrid.tsx
@@ -1,7 +1,7 @@
 // components/entity/client/ClientGrid.tsx
 import { GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import { EntityGrid } from "@/components/entity/EntityGrid";
-import type { Client } from "@/api/models/Client";
+import type { Client_Input as Client } from "@/api/models/Client_Input";
 import { formatEnum, formatDate } from "@/app/lib/util";
 
 const clientColumns: GridColDef<Client>[] = [

--- a/frontend/src/components/entity/contact/ContactDetailView.tsx
+++ b/frontend/src/components/entity/contact/ContactDetailView.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { EntityDetailView } from "@/components/entity/EntityDetailView";
-import type { Contact } from "@/api/models/Contact";
+import type { Contact_Input as Contact } from "@/api/models/Contact_Input";
 
 export const detailFields: { label: string; field: keyof Contact; render?: (value: Contact[keyof Contact], item: Contact) => React.ReactNode }[] = [
   { label: "Title", field: "title" },

--- a/frontend/src/components/entity/contact/ContactEditView.tsx
+++ b/frontend/src/components/entity/contact/ContactEditView.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { EntityEditView } from "@/components/entity/EntityEditView";
-import { Contact, ContactRequired } from "@/api/models/Contact";
+import { Contact_Input as Contact, Contact_InputRequired as ContactRequired } from "@/api/models/Contact_Input";
 import { applyRequiredFlags } from "@/app/lib/type-utils";
 
 const baseFields = [

--- a/frontend/src/components/entity/contact/ContactGrid.tsx
+++ b/frontend/src/components/entity/contact/ContactGrid.tsx
@@ -1,6 +1,6 @@
 import { GridColDef } from "@mui/x-data-grid";
 import { EntityGrid } from "@/components/entity/EntityGrid";
-import type { Contact } from "@/api/models/Contact";
+import type { Contact_Input as Contact } from "@/api/models/Contact_Input";
 
 const contactColumns: GridColDef[] = [
     { field: "name", headerName: "Name", flex: 1, minWidth: 150 },

--- a/frontend/src/components/entity/document/DocumentDetailView.tsx
+++ b/frontend/src/components/entity/document/DocumentDetailView.tsx
@@ -10,7 +10,7 @@ import {
 } from "@mui/material";
 import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
 import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
-import type { ProjectDocument } from "@/api/models/ProjectDocument";
+import type { ProjectDocument_Input as ProjectDocument } from "@/api/models/ProjectDocument_Input";
 
 function EmbeddingHeatmap({ embedding }: { embedding: number[] | null | undefined }) {
   if (!embedding || embedding.length === 0) {

--- a/frontend/src/components/entity/document/DocumentEditView.tsx
+++ b/frontend/src/components/entity/document/DocumentEditView.tsx
@@ -2,8 +2,8 @@
 
 import React from "react";
 import { EntityEditView } from "@/components/entity/EntityEditView";
-import type { Project } from "@/api/models/Project";
-import { ProjectDocument, ProjectDocumentRequired } from "@/api/models/ProjectDocument";
+import type { Project_Input as Project } from "@/api/models/Project_Input";
+import { ProjectDocument_Input as ProjectDocument, ProjectDocument_InputRequired as ProjectDocumentRequired } from "@/api/models/ProjectDocument_Input";
 import { useProjectReferenceField } from "@/hooks/useProjectReferenceField";
 import { applyRequiredFlags } from "@/app/lib/type-utils";
 

--- a/frontend/src/components/entity/document/DocumentGrid.tsx
+++ b/frontend/src/components/entity/document/DocumentGrid.tsx
@@ -13,7 +13,7 @@ import {
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
 import VisibilityOutlinedIcon from "@mui/icons-material/VisibilityOutlined";
-import type { ProjectDocument } from "@/api/models/ProjectDocument";
+import type { ProjectDocument_Input as ProjectDocument } from "@/api/models/ProjectDocument_Input";
 
 interface DocumentGridProps {
   rows: ProjectDocument[];

--- a/frontend/src/components/entity/organization/OrganizationEditView.tsx
+++ b/frontend/src/components/entity/organization/OrganizationEditView.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { EntityEditView } from "@/components/entity/EntityEditView";
 import type { OrganizationResponse } from "@/api/models/OrganizationResponse";
 import type { OrganizationCreate } from "@/api/models/OrganizationCreate";
-import type { Tier } from "@/api/models/Tier";
+import type { Tier_Input as Tier } from "@/api/models/Tier_Input";
 import { useTierReferenceField } from "@/hooks/useTierReferenceField";
 import useUserRole from "@/hooks/useUserRole";
 

--- a/frontend/src/components/entity/project/ProjectDetailView.tsx
+++ b/frontend/src/components/entity/project/ProjectDetailView.tsx
@@ -1,9 +1,9 @@
 // components/entity/project/ProjectDetailView.tsx
 import React, { useEffect, useState, useMemo } from "react";
 import { DetailField, EntityDetailView } from "@/components/entity/EntityDetailView";
-import type { Project } from "@/api/models/Project";
-import type { Client } from "@/api/models/Client";
-import type { ProjectDocument } from "@/api/models/ProjectDocument";
+import type { Project_Input as Project } from "@/api/models/Project_Input";
+import type { Client_Input as Client } from "@/api/models/Client_Input";
+import type { ProjectDocument_Input as ProjectDocument } from "@/api/models/ProjectDocument_Input";
 import Link from "next/link";
 import { ClientsService } from "@/api/services/ClientsService";
 import { DocumentsService } from "@/api/services/DocumentsService";

--- a/frontend/src/components/entity/project/ProjectEditView.tsx
+++ b/frontend/src/components/entity/project/ProjectEditView.tsx
@@ -2,8 +2,8 @@
 
 import React from "react";
 import { EntityEditView } from "@/components/entity/EntityEditView";
-import type { Client } from "@/api/models/Client";
-import { Project, ProjectRequired } from "@/api/models/Project";
+import type { Client_Input as Client } from "@/api/models/Client_Input";
+import { Project_Input as Project, Project_InputRequired as ProjectRequired } from "@/api/models/Project_Input";
 import { useClientReferenceField } from "@/hooks/useClientReferenceField";
 import {applyRequiredFlags} from "@/app/lib/type-utils";
 

--- a/frontend/src/components/entity/project/ProjectGrid.tsx
+++ b/frontend/src/components/entity/project/ProjectGrid.tsx
@@ -1,7 +1,7 @@
 // components/entity/project/ProjectGrid.tsx
 import { GridColDef } from "@mui/x-data-grid";
 import { EntityGrid } from "@/components/entity/EntityGrid";
-import type { Project } from "@/api/models/Project";
+import type { Project_Input as Project } from "@/api/models/Project_Input";
 import { formatDate } from "@/app/lib/util";
 
 const projectColumns: GridColDef<Project>[] = [

--- a/frontend/src/components/entity/tier/TierDetailView.tsx
+++ b/frontend/src/components/entity/tier/TierDetailView.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { EntityDetailView } from "@/components/entity/EntityDetailView";
 import { formatDateTime } from "@/app/lib/util";
-import type { Tier } from "@/api/models/Tier";
+import type { Tier_Input as Tier } from "@/api/models/Tier_Input";
 
 export const detailFields: {
   label: string;

--- a/frontend/src/components/entity/tier/TierEditView.tsx
+++ b/frontend/src/components/entity/tier/TierEditView.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { EntityEditView } from "@/components/entity/EntityEditView";
-import type { Tier } from "@/api/models/Tier";
+import type { Tier_Input as Tier } from "@/api/models/Tier_Input";
 
 interface TierEditViewProps {
   item: Tier;

--- a/frontend/src/components/entity/tier/TierGrid.tsx
+++ b/frontend/src/components/entity/tier/TierGrid.tsx
@@ -3,7 +3,7 @@
 "use client";
 import { GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import { EntityGrid } from "@/components/entity/EntityGrid";
-import type { Tier } from "@/api/models/Tier";
+import type { Tier_Input as Tier } from "@/api/models/Tier_Input";
 
 interface TierGridProps {
   rows: Tier[];

--- a/frontend/src/hooks/useAddressReferenceField.ts
+++ b/frontend/src/hooks/useAddressReferenceField.ts
@@ -2,7 +2,7 @@
 import { useCallback } from "react";
 import { useReferenceField } from "./useReferenceField";
 import { AddressesService } from "@/api/services/AddressesService";
-import type { Address } from "@/api/models/Address";
+import type { Address_Input as Address } from "@/api/models/Address_Input";
 
 export function useAddressReferenceField() {
   const fetchAddresses = useCallback(

--- a/frontend/src/hooks/useClientReferenceField.ts
+++ b/frontend/src/hooks/useClientReferenceField.ts
@@ -2,7 +2,7 @@
 import { useCallback } from "react";
 import { useReferenceField } from "@/hooks/useReferenceField";
 import { ClientsService } from "@/api/services/ClientsService";
-import type { Client } from "@/api/models/Client";
+import type { Client_Input as Client } from "@/api/models/Client_Input";
 
 export function useClientReferenceField() {
   const fetchClients = useCallback(

--- a/frontend/src/hooks/useContactReferenceField.ts
+++ b/frontend/src/hooks/useContactReferenceField.ts
@@ -2,7 +2,7 @@
 import { useCallback } from "react";
 import { useReferenceField } from "./useReferenceField";
 import { ContactsService } from "@/api/services/ContactsService";
-import type { Contact } from "@/api/models/Contact";
+import type { Contact_Input as Contact } from "@/api/models/Contact_Input";
 
 export function useContactReferenceField() {
   const fetchContacts = useCallback(

--- a/frontend/src/hooks/useProjectReferenceField.ts
+++ b/frontend/src/hooks/useProjectReferenceField.ts
@@ -2,7 +2,7 @@
 import { useCallback } from "react";
 import { useReferenceField } from "@/hooks/useReferenceField";
 import { ProjectsService } from "@/api/services/ProjectsService";
-import type { Project } from "@/api/models/Project";
+import type { Project_Input as Project } from "@/api/models/Project_Input";
 
 interface UseProjectReferenceOptions {
   skip?: number;

--- a/frontend/src/hooks/useTierReferenceField.ts
+++ b/frontend/src/hooks/useTierReferenceField.ts
@@ -2,7 +2,7 @@
 import { useCallback } from "react";
 import { useReferenceField } from "@/hooks/useReferenceField";
 import { TiersService } from "@/api/services/TiersService";
-import type { Tier } from "@/api/models/Tier";
+import type { Tier_Input as Tier } from "@/api/models/Tier_Input";
 
 export function useTierReferenceField() {
   const fetchTiers = useCallback(


### PR DESCRIPTION
Update OpenAPI model imports after regeneration.

**Key changes:**
- Removed usage of old flat models (Address, Client, etc.)
- Replaced all imports with *_Input versions
- Kept original type names using aliases (e.g. Address_Input as Address)