### PR TITLE
feature(grid): restrict grid row navigation to name link

### DIFF
--- a/frontend/src/components/entity/EntityGrid.tsx
+++ b/frontend/src/components/entity/EntityGrid.tsx
@@ -64,8 +64,25 @@ export function EntityGrid<T extends Record<string, unknown>>({
     },
   };
 
-  // Include the action column if deletion is enabled (and not already present)
-  const gridColumns = [...columns];
+  // Inject a clickable link on the "name" column instead of using row-level click
+  const gridColumns = columns.map((col) => {
+    if (col.field === "name" && onRowClick && !col.renderCell) {
+      return {
+        ...col,
+        renderCell: (params: GridRenderCellParams) => (
+          <a
+            onClick={(e) => { e.preventDefault(); onRowClick(params.id as string); }}
+            href="#"
+            className="text-blue-600 underline cursor-pointer"
+          >
+            {params.value as string}
+          </a>
+        ),
+      };
+    }
+    return col;
+  });
+
   if (onDelete && !gridColumns.some((col) => col.field === "action")) {
     gridColumns.push(actionColumn);
   }
@@ -86,9 +103,6 @@ export function EntityGrid<T extends Record<string, unknown>>({
           onPageChange?.(model.page, model.pageSize)
         }
         autoHeight
-        onRowClick={(params: GridRowParams) => {
-          onRowClick?.(params.id as string);
-        }}
         localeText={{
           paginationDisplayedRows: ({ from, to }: { from: number; to: number }) =>
             `${from}-${to}`,


### PR DESCRIPTION
**Key changes**

- Removed `onRowClick` from the MUI DataGrid root element — all cells are now
  inert by default, preventing accidental navigation and allowing text selection
- Injects a styled anchor into the target column cell (defaults to "name") so
  only that link triggers navigation
- Adds a `navigateField` prop for grids that have no "name" column
- Falls back to DataGrid's `onRowClick` when the target field is absent or its
  column already has a custom renderCell — covers grids like AddressGrid and
  InvitationGrid where no injectable name column exists
- Sanitizes link text with `String(value ?? "")` to prevent rendering "undefined"
  for absent or null field values