### PR TITLE
ai panel: strip large arrays from context, pass full URL path, inject entity ID hint

### DIFF
--- a/backend/instacrud/ai/functions/crud.py
+++ b/backend/instacrud/ai/functions/crud.py
@@ -520,6 +520,24 @@ def _parse_filters_arg(filters: Any) -> dict:
 IMMUTABLE_FIELDS = {"id", "_id", "created_at", "created_by", "updated_at", "updated_by"}
 
 
+def _strip_fields(doc: dict[str, Any], fields: list[str]) -> None:
+    """Replace each excluded field with a placeholder so the AI knows it exists but was omitted."""
+    for f in fields:
+        if f not in doc:
+            continue
+        val = doc[f]
+        if isinstance(val, dict):
+            doc[f] = f"<stripped: {len(val)} entries>"
+        elif isinstance(val, list):
+            doc[f] = f"<stripped: {len(val)} items>"
+        elif isinstance(val, str):
+            doc[f] = f"<stripped: {len(val)} chars>"
+        elif val is None:
+            doc.pop(f)
+        else:
+            doc[f] = "<stripped>"
+
+
 # ── Generic CRUD ──────────────────────────────────────────────────────────────
 
 async def crud_list(
@@ -528,21 +546,25 @@ async def crud_list(
     skip: int = 0,
     limit: int = 10,
     sort: str = "-updated_at",
+    exclude_fields: Optional[list[str]] = None,
 ) -> list[dict[str, Any]]:
     _require_auth()
     _check_system_access(model_name)
     await _llm_guardrail("crud_list", {"model_name": model_name, "filters": filters, "skip": skip, "limit": limit, "sort": sort})
-    logger.info("[tool:crud_list] model={} filters={} skip={} limit={} sort={}", model_name, filters, skip, limit, sort)
+    logger.info("[tool:crud_list] model={} filters={} skip={} limit={} sort={} exclude={}", model_name, filters, skip, limit, sort, exclude_fields)
     """Return a paginated list of documents from any CRUD model.
 
     Args:
-        model_name: Python class name of the Beanie model (e.g. "Client").
-        filters:    MongoDB query filter — dict or JSON string.
-                    Supports $and, $or, $in, $eq, $ne, $gt, $gte, $lt, $lte, etc.
-                    Example: {"type": "COMPANY"} or '{"code": {"$in": ["ACME", "FOO"]}}'
-        skip:       Number of documents to skip (for pagination).
-        limit:      Maximum number of documents to return (1–500).
-        sort:       Sort expression, e.g. "-updated_at" (descending) or "name".
+        model_name:     Python class name of the Beanie model (e.g. "Client").
+        filters:        MongoDB query filter — dict or JSON string.
+                        Supports $and, $or, $in, $eq, $ne, $gt, $gte, $lt, $lte, etc.
+                        Example: {"type": "COMPANY"} or '{"code": {"$in": ["ACME", "FOO"]}}'
+        skip:           Number of documents to skip (for pagination).
+        limit:          Maximum number of documents to return (1–500).
+        sort:           Sort expression, e.g. "-updated_at" (descending) or "name".
+        exclude_fields: List of top-level field names to strip from each result to reduce
+                        response size. Useful for models that contain large arrays or
+                        blobs that would overflow the LLM context window.
 
     Returns:
         List of serialised document dicts.
@@ -552,21 +574,32 @@ async def crud_list(
     _validate_filter_values(query)
     limit = max(1, min(limit, 500))
     docs = await model.find(query).sort(sort).skip(skip).limit(limit).to_list()
-    return [_doc_to_dict(d) for d in docs]
+    results = [_doc_to_dict(d) for d in docs]
+    if exclude_fields:
+        for doc in results:
+            _strip_fields(doc, exclude_fields)
+    return results
 
 
-async def crud_get(model_name: str, item_id: str) -> dict[str, Any]:
+async def crud_get(
+    model_name: str,
+    item_id: str,
+    exclude_fields: Optional[list[str]] = None,
+) -> dict[str, Any]:
     _require_auth()
     _check_system_access(model_name)
-    logger.info("[tool:crud_get] model={} item_id={}", model_name, item_id)
+    logger.info("[tool:crud_get] model={} item_id={} exclude={}", model_name, item_id, exclude_fields)
     """Fetch a single document by its MongoDB ObjectId.
 
     Args:
-        model_name: Python class name of the Beanie model (e.g. "Project").
-        item_id:    24-hex-character ObjectId string.
+        model_name:     Python class name of the Beanie model (e.g. "Project").
+        item_id:        24-hex-character ObjectId string.
+        exclude_fields: Top-level fields to strip and replace with size hints.
+                        Use to avoid context overflows on models with large arrays or blobs.
 
     Returns:
-        Serialised document dict.
+        Serialised document dict. Stripped fields appear as "<stripped: N entries>" so
+        you know they exist and can fetch them separately if needed.
 
     Raises:
         ValueError: if the document is not found.
@@ -575,7 +608,10 @@ async def crud_get(model_name: str, item_id: str) -> dict[str, Any]:
     doc = await model.get(item_id)
     if doc is None:
         raise ValueError(f"{model_name} with id={item_id!r} not found")
-    return _doc_to_dict(doc)
+    result = _doc_to_dict(doc)
+    if exclude_fields:
+        _strip_fields(result, exclude_fields)
+    return result
 
 
 async def crud_create(model_name: str, data: dict[str, Any]) -> dict[str, Any]:
@@ -950,11 +986,22 @@ _FILTERS_PROP = {
     ),
 }
 
+_EXCLUDE_FIELDS_PROP = {
+    "type": "array",
+    "items": {"type": "string"},
+    "description": (
+        "Top-level field names to strip from results and replace with size hints "
+        "(e.g. '<stripped: 42 items>'). Use to avoid context overflows on models "
+        "that contain large arrays or blobs."
+    ),
+}
+
 CRUD_LIST_TOOL = ToolDef(
     name="crud_list",
     description=(
         "Return a paginated list of documents from any CRUD model. "
-        "Use this to query Clients, Contacts, Projects, ProjectDocuments, Addresses, or Conversations."
+        "Use this to query Clients, Contacts, Projects, ProjectDocuments, Addresses, or Conversations. "
+        "Pass exclude_fields to strip large arrays/blobs and avoid context overflow."
     ),
     input_schema={
         "type": "object",
@@ -968,6 +1015,7 @@ CRUD_LIST_TOOL = ToolDef(
                 "description": 'Sort field. Prefix with "-" for descending. Default: "-updated_at".',
                 "default": "-updated_at",
             },
+            "exclude_fields": _EXCLUDE_FIELDS_PROP,
         },
         "required": ["model_name"],
     },
@@ -976,12 +1024,16 @@ CRUD_LIST_TOOL = ToolDef(
 
 CRUD_GET_TOOL = ToolDef(
     name="crud_get",
-    description="Fetch a single document by its MongoDB ObjectId from any CRUD model.",
+    description=(
+        "Fetch a single document by its MongoDB ObjectId from any CRUD model. "
+        "Pass exclude_fields to strip large arrays/blobs and avoid context overflow."
+    ),
     input_schema={
         "type": "object",
         "properties": {
             "model_name": _MODEL_NAME_PROP,
             "item_id": _ITEM_ID_PROP,
+            "exclude_fields": _EXCLUDE_FIELDS_PROP,
         },
         "required": ["model_name", "item_id"],
     },

--- a/frontend/src/components/ai-panel/InPageChat.tsx
+++ b/frontend/src/components/ai-panel/InPageChat.tsx
@@ -7,7 +7,7 @@ import React, {
   useMemo,
   useEffect,
 } from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { useAiPanel } from "@/context/AiPanelContext";
 import { useAiModels } from "@/app/(admin)/(others-pages)/ai-assistant/hooks/useAiModels";
 import { useConversation } from "@/app/(admin)/(others-pages)/ai-assistant/hooks/useConversation";
@@ -28,6 +28,14 @@ const GENERIC_SYSTEM_PROMPT =
   "The current page content is:\n$CONTEXT\n\n" +
   "Help the user understand, navigate, or act on what they see.";
 
+/** Maps URL path segments (plural) to the Beanie model name used in crud_get/crud_list. */
+const PATH_TO_MODEL: Record<string, string> = {
+  projects: "Project",
+  clients: "Client",
+  contacts: "Contact",
+  addresses: "Address",
+};
+
 const MAX_RENDERED_MESSAGES = 50;
 
 export function InPageChat() {
@@ -40,6 +48,8 @@ export function InPageChat() {
   } = useAiPanel();
 
   const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const fullPath = searchParams.toString() ? `${pathname}?${searchParams.toString()}` : pathname;
 
   const [input, setInput] = useState("");
   const [reasoningContent, setReasoningContent] = useState<string | null>(null);
@@ -49,9 +59,17 @@ export function InPageChat() {
   // Plain expression — no useMemo — so we don't change the hook call order
   // below. useMemo would shift every subsequent hook to a different slot in
   // React's internal linked list, which silently corrupts state.
-  const effectiveSystemPrompt = pageSystemPrompt?.trim()
+  const entityId = searchParams.get("id");
+  const pathSegment = pathname.split("/").filter(Boolean).pop() ?? "";
+  const detectedModel = PATH_TO_MODEL[pathSegment];
+  const baseSystemPrompt = pageSystemPrompt?.trim()
     ? pageSystemPrompt
     : GENERIC_SYSTEM_PROMPT;
+  const effectiveSystemPrompt =
+    entityId && detectedModel
+      ? `${baseSystemPrompt}\n\nIMPORTANT: The user is viewing ${detectedModel} with ID "${entityId}". ` +
+        `Use crud_get("${detectedModel}", "${entityId}") to fetch this entity directly — do NOT use crud_list.`
+      : baseSystemPrompt;
 
   // ── Models ──────────────────────────────────────────────────────────────
   const {
@@ -92,13 +110,13 @@ export function InPageChat() {
     setChatModelId,
     mode: "chat",
     initialSystemPrompt: effectiveSystemPrompt,
-    initialPath: pathname,
+    initialPath: fullPath,
     initialContext: pageContext || null,
     initialTools: "*",
   });
 
   // ── Sync live page context into the conversation ─────────────────────────
-  // pageContext / pathname are set asynchronously by the page's useEffect, so
+  // pageContext / fullPath are set asynchronously by the page's useEffect, so
   // useState(initialContext) in useConversation captures an empty string on
   // the first render.  This effect keeps the conversation params up-to-date
   // so the stored context (synced to the server) always reflects the current
@@ -106,10 +124,10 @@ export function InPageChat() {
   useEffect(() => {
     updateAiParams({
       systemPrompt: effectiveSystemPrompt,
-      path: pathname,
+      path: fullPath,
       context: pageContext || null,
     });
-  }, [pageContext, pathname, effectiveSystemPrompt, updateAiParams]);
+  }, [pageContext, fullPath, effectiveSystemPrompt, updateAiParams]);
 
   // ── Chat stream ──────────────────────────────────────────────────────────
   const {
@@ -145,7 +163,7 @@ export function InPageChat() {
     selectedModel,
     // Page-aware parameters
     systemPrompt: effectiveSystemPrompt,
-    path: pathname,
+    path: fullPath,
     context: pageContext || null,
     tools: "*",
   });

--- a/frontend/src/components/entity/EntityDetailView.tsx
+++ b/frontend/src/components/entity/EntityDetailView.tsx
@@ -33,10 +33,20 @@ export function EntityDetailView<T extends Record<string, unknown>>({
   modelName,
   publishAiContext = true,
 }: EntityDetailViewProps<T>) {
-  // Publish current item to the in-page AI assistant
+  // Publish current item to the in-page AI assistant.
+  // Strip large arrays to avoid blowing the LLM context window — the AI can
+  // fetch them on demand via crud_get with specific fields.
   const contextJson = useMemo(() => {
     try {
-      return JSON.stringify(item, null, 2);
+      const stripped: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(item)) {
+        if (Array.isArray(v) && v.length > 10) {
+          stripped[k] = `<stripped: ${v.length} items>`;
+        } else {
+          stripped[k] = v;
+        }
+      }
+      return JSON.stringify(stripped, null, 2);
     } catch {
       return "";
     }


### PR DESCRIPTION
## Summary

- **EntityDetailView**: serialize arrays with >10 items as `<stripped: N items>` so the AI context never blows the LLM token limit; the AI can follow up with `crud_get` + `exclude_fields` when it needs the full data
- **InPageChat**: use `useSearchParams` so `$PATH` includes `?id=…` query params; when the URL contains `?id=<entityId>`, inject an explicit `crud_get` directive into the system prompt so the AI fetches the right entity directly instead of falling back to `crud_list`
- **crud.py**: add `_strip_fields` helper + `exclude_fields` param to `crud_list` and `crud_get` so the AI can request lightweight responses for any model that carries large arrays or blobs; expose the param in the ToolDef schemas

## Problem solved

When the AI panel was open on a detail page (e.g. `/clients?id=abc123`), two bugs caused it to answer about the wrong entity:
1. The full entity JSON (including large arrays) was serialized into `$CONTEXT`, causing token limit errors for data-heavy models
2. `$PATH` was only the pathname (`/clients`) without the query string, so the AI had no ID to work with and fell back to `crud_list` sorted by `-updated_at`, returning whichever entity was most recently modified

## Test plan

- [ ] Open any entity detail page with `?id=…` in the URL; ask the AI panel "what is this?" — it should call `crud_get` with the correct ID on the first tool call, not `crud_list`
- [ ] Verify models with large array fields no longer cause 500 errors from token limit overflow
- [ ] Verify `crud_list` and `crud_get` both accept `exclude_fields` and return `<stripped: N items>` placeholders for excluded fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)