### PR TITLE
Fix server-side 401 handling in MeContext and ProvisioningGuard

### DIFF
--- a/frontend/src/app/lib/util.ts
+++ b/frontend/src/app/lib/util.ts
@@ -4,7 +4,7 @@
 import React from "react";
 import { useRouter } from "next/navigation";
 import { OpenAPI } from "@/api";
-import { clearMeCache } from "@/context/MeContext";
+import { clearMeCache, resetAuthFailed } from "@/context/MeContext";
 import { useEffect, useState } from "react";
 import { createTheme } from "@mui/material/styles";
 import { DetailField } from "@/components/entity/EntityDetailView";
@@ -16,6 +16,7 @@ export function logout(router: ReturnType<typeof useRouter>, reason?: { message:
   localStorage.removeItem("token");
   localStorage.removeItem("user.info");
   clearMeCache();
+  resetAuthFailed();
   sessionStorage.setItem("originalUrl", window.location.pathname);
   OpenAPI.TOKEN = undefined;
   router.push(redirectPath);

--- a/frontend/src/components/auth/ProvisioningGuard.tsx
+++ b/frontend/src/components/auth/ProvisioningGuard.tsx
@@ -1,13 +1,15 @@
 // components/auth/ProvisioningGuard.tsx
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import useAuth from "@/hooks/useAuth";
 import { useMeContext } from "@/context/MeContext";
 import { MeService } from "@/api/services/MeService";
 import type { MeResponse } from "@/api/models/MeResponse";
 import AuthLoader from "@/components/auth/AuthLoader";
 import { getApiErrorInfo } from "@/app/lib/api-error";
+import { logout as performLogout } from "@/app/lib/util";
 
 const PROVISIONING_TIMEOUT = 5 * 60 * 1000; // 5 minutes
 const POLL_INTERVAL = 5000;
@@ -49,7 +51,7 @@ function resolveProvisioningStatus(me: MeResponse): "ready" | "provisioning" | "
 
 export default function ProvisioningGuard({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isLoadingAuth } = useAuth();
-  const { me, isLoading: meLoading } = useMeContext();
+  const { me, isLoading: meLoading, authFailed } = useMeContext();
 
   // Keep me in a ref so the effect can read the latest value without re-running
   // when MeContext does a background stale-while-revalidate (~60s TTL). Without this,
@@ -57,22 +59,56 @@ export default function ProvisioningGuard({ children }: { children: React.ReactN
   const meRef = useRef(me);
   useEffect(() => { meRef.current = me; }, [me]);
 
+  // Keep authFailed in a ref for the same reason — readable inside async callbacks
+  // of the main effect without adding it to that effect's dependency array.
+  const authFailedRef = useRef(authFailed);
+  useEffect(() => { authFailedRef.current = authFailed; }, [authFailed]);
+
   const [status, setStatus] = useState<"loading" | "provisioning" | "failed" | "ready">("loading");
 
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const logout = () => {
-    try {
-      localStorage.removeItem("token");
-      localStorage.removeItem("user.info");
-      localStorage.removeItem(ORG_STATUS_CACHE_KEY);
-    } catch {}
-    window.location.href = "/signin";
-  };
+  const router = useRouter();
+  // Prevents duplicate logout calls from concurrent effects or polling callbacks.
+  const logoutCalledRef = useRef(false);
+
+  // Delegates to the shared logout utility for canonical token/cache cleanup and
+  // router-based navigation (avoids duplicating that logic here).
+  // ORG_STATUS_CACHE_KEY is provisioning-specific so it is cleared before delegating.
+  // router.push (inside performLogout) is preferred over window.location.href to
+  // avoid a full page reload; a hard reload is not needed since all auth state is
+  // cleared synchronously before navigation.
+  const signOut = useCallback((reason?: { message: string; action: string }) => {
+    if (logoutCalledRef.current) return;
+    logoutCalledRef.current = true;
+    try { localStorage.removeItem(ORG_STATUS_CACHE_KEY); } catch {}
+    performLogout(router, reason);
+  }, [router]);
+
+  // Keep signOut in a ref so poll() and initialCheck() — which close over the main
+  // effect's scope — can always call the latest version without being deps of that effect.
+  const signOutRef = useRef(signOut);
+  useEffect(() => { signOutRef.current = signOut; }, [signOut]);
+
+  // React immediately to a server-side 401 surfaced by MeContext.
+  // Client-side JWT validity ≠ server-side auth validity: the token may be
+  // cryptographically intact but rejected (user missing, DB switched, etc.).
+  // A 401 from /me is a terminal auth failure — not a transient provisioning
+  // delay — so we must logout rather than enter the provisioning retry loop.
+  useEffect(() => {
+    if (authFailed) {
+      setStatus("loading");
+      signOut({ message: "Your session has expired", action: "Please sign in again" });
+    }
+  }, [authFailed, signOut]);
 
   useEffect(() => {
     if (!isAuthenticated || isLoadingAuth || meLoading) return;
+    // If MeContext already signalled a server-side auth failure, the effect above
+    // handles logout. Skip the provisioning flow entirely to avoid a redundant
+    // /me call and to prevent starting a polling loop that would always hit 401.
+    if (authFailed || logoutCalledRef.current) return;
 
     let cancelled = false;
 
@@ -93,7 +129,12 @@ export default function ProvisioningGuard({ children }: { children: React.ReactN
       } catch (err) {
         if (cancelled) return;
         const { status: httpStatus } = getApiErrorInfo(err);
-        if (httpStatus === 403 || httpStatus === 404 || httpStatus === 501) {
+        if (httpStatus === 401) {
+          // Token rejected mid-session (revoked, user deleted, etc.).
+          // 401 is terminal — polling will never succeed. Logout immediately.
+          stopPolling();
+          signOutRef.current({ message: "Your session has expired", action: "Please sign in again" });
+        } else if (httpStatus === 403 || httpStatus === 404 || httpStatus === 501) {
           setStatus("failed");
           stopPolling();
         }
@@ -115,12 +156,19 @@ export default function ProvisioningGuard({ children }: { children: React.ReactN
       // MeContext sets me=null on any fetch error. Fall back to a direct call so that
       // transient network errors don't permanently show "Provisioning Failed".
       if (meData === null) {
+        // If MeContext already flagged a 401, avoid a redundant round-trip —
+        // the authFailed effect is already handling logout.
+        if (authFailedRef.current) return;
         try {
           meData = await MeService.getMeMeGet();
         } catch (err) {
           if (cancelled) return;
           const { status: httpStatus } = getApiErrorInfo(err);
-          if (httpStatus === 403 || httpStatus === 404 || httpStatus === 501) {
+          if (httpStatus === 401) {
+            // Server rejected the token — auth failure, not a provisioning delay.
+            // Must not poll: every subsequent request will also return 401.
+            signOutRef.current({ message: "Your session has expired", action: "Please sign in again" });
+          } else if (httpStatus === 403 || httpStatus === 404 || httpStatus === 501) {
             setStatus("failed");
           } else {
             // Transient error: start polling so the 5-minute timeout eventually shows the
@@ -147,7 +195,9 @@ export default function ProvisioningGuard({ children }: { children: React.ReactN
       cancelled = true;
       stopPolling();
     };
-  }, [isAuthenticated, isLoadingAuth, meLoading]); // me intentionally excluded — read via meRef
+  // me intentionally excluded — read via meRef to avoid restarting the 5-min timeout
+  // on background stale-while-revalidate refreshes. signOut read via signOutRef.
+  }, [isAuthenticated, isLoadingAuth, meLoading, authFailed]);
 
   if (isLoadingAuth || meLoading || status === "loading") {
     return <AuthLoader />;
@@ -165,7 +215,7 @@ export default function ProvisioningGuard({ children }: { children: React.ReactN
         </p>
 
         <button
-          onClick={logout}
+          onClick={() => signOut()}
           className="mt-6 px-4 py-2 text-sm font-medium text-white bg-gray-600 rounded-md hover:bg-gray-700"
         >
           Sign out
@@ -202,7 +252,7 @@ export default function ProvisioningGuard({ children }: { children: React.ReactN
           </button>
 
           <button
-            onClick={logout}
+            onClick={() => signOut()}
             className="px-4 py-2 text-white bg-gray-600 rounded-md hover:bg-gray-700"
           >
             Sign out

--- a/frontend/src/context/MeContext.tsx
+++ b/frontend/src/context/MeContext.tsx
@@ -4,6 +4,7 @@
 import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
 import { MeService } from "@/api/services/MeService";
 import type { MeResponse } from "@/api/models/MeResponse";
+import { ApiError } from "@/api/core/ApiError";
 
 const SESSION_CACHE_KEY = "me.cache";
 const CACHE_TTL_MS = 60 * 1000; // 60 seconds
@@ -36,9 +37,32 @@ export function clearMeCache() {
   } catch {}
 }
 
+// Module-level ref that lets non-React code (e.g. the logout utility) reset
+// authFailed state without requiring context access or prop drilling. This
+// mirrors the same pattern used by clearMeCache above.
+//
+// Safe as a singleton because MeProvider is intentionally mounted once in the
+// component tree. The useEffect cleanup in MeProvider nullifies it on unmount
+// so a stale setter cannot fire after the provider is gone.
+//
+// IMPORTANT: performLogout MUST call resetAuthFailed() alongside clearMeCache().
+// If MeProvider is ever promoted to the root layout it will persist across
+// route group navigations (including /signin), so authFailed=true set during
+// a 401 would still be true when the user re-logs in — triggering an infinite
+// logout loop unless it is explicitly cleared here.
+let _resetAuthFailed: (() => void) | null = null;
+
+export function resetAuthFailed() {
+  _resetAuthFailed?.();
+}
+
 interface MeContextValue {
   me: MeResponse | null;
   isLoading: boolean;
+  // true when the server rejected the token with 401 (e.g. user missing after a DB switch).
+  // Distinct from me===null, which can also result from a transient network error.
+  // Client-side JWT validity does NOT imply server-side auth validity.
+  authFailed: boolean;
   refetch: () => Promise<void>;
   updateMe: (data: MeResponse) => void;
 }
@@ -49,6 +73,7 @@ export function MeProvider({ children }: { children: React.ReactNode }) {
   const cached = readCache();
   const [me, setMe] = useState<MeResponse | null>(cached?.data ?? null);
   const [isLoading, setIsLoading] = useState(!cached);
+  const [authFailed, setAuthFailed] = useState(false);
   const fetchingRef = useRef(false);
 
   const fetchMe = useCallback(async () => {
@@ -58,8 +83,15 @@ export function MeProvider({ children }: { children: React.ReactNode }) {
       const data = await MeService.getMeMeGet();
       setMe(data);
       writeCache(data);
+      setAuthFailed(false); // reset in case a prior fetch failed (e.g. after token refresh)
     } catch (error) {
       console.error("Failed to fetch /me:", error);
+      // A 401 means the server actively rejected the token — not a transient error.
+      // Surface this explicitly so downstream guards can react without re-fetching.
+      if (error instanceof ApiError && error.status === 401) {
+        setAuthFailed(true);
+        clearMeCache(); // don't serve stale data after a token rejection
+      }
       setMe(null);
     } finally {
       setIsLoading(false);
@@ -81,13 +113,21 @@ export function MeProvider({ children }: { children: React.ReactNode }) {
     fetchMe();
   }, [fetchMe]);
 
+  // Wire the module-level ref to the live state setter so resetAuthFailed()
+  // can reach into this provider from outside React (e.g. performLogout).
+  // Cleanup nullifies it on unmount to prevent a stale call after unmount.
+  useEffect(() => {
+    _resetAuthFailed = () => setAuthFailed(false);
+    return () => { _resetAuthFailed = null; };
+  }, []); // setAuthFailed is a stable dispatcher — intentionally no deps
+
   const updateMe = useCallback((data: MeResponse) => {
     setMe(data);
     writeCache(data);
   }, []);
 
   return (
-    <MeContext.Provider value={{ me, isLoading, refetch: fetchMe, updateMe }}>
+    <MeContext.Provider value={{ me, isLoading, authFailed, refetch: fetchMe, updateMe }}>
       {children}
     </MeContext.Provider>
   );

--- a/frontend/test/e2e/auth-failure.spec.ts
+++ b/frontend/test/e2e/auth-failure.spec.ts
@@ -1,0 +1,202 @@
+/**
+ * E2E regression tests for the 401 → auth-failure flow.
+ *
+ * Reproduces the scenario where a JWT is locally valid (not expired) but the
+ * server rejects it — e.g. after a backend DB swap invalidates user records.
+ *
+ * Before the fix:
+ *   - MeContext swallowed the 401, set me=null
+ *   - ProvisioningGuard treated 401 as a transient error and started polling
+ *   - The app showed an infinite spinner for up to 5 minutes
+ *
+ * After the fix:
+ *   - MeContext surfaces authFailed=true on 401
+ *   - ProvisioningGuard's dedicated effect fires, sets status="loading", calls signOut()
+ *   - The app redirects to /signin within seconds
+ *
+ * Run:
+ *   npx playwright test test/e2e/auth-failure.spec.ts
+ */
+
+import { test, expect } from './fixtures';
+import type { Page, Route, Frame } from '@playwright/test';
+
+const ME_URL = '**/api/v1/me';
+const ME_401_RESPONSE = {
+  status: 401,
+  contentType: 'application/json',
+  body: JSON.stringify({ detail: 'User not found' }),
+};
+
+/** Clear the MeContext sessionStorage cache so the next mount triggers fetchMe(). */
+async function clearMeCache(page: Page) {
+  await page.evaluate(() => sessionStorage.removeItem('me.cache'));
+}
+
+// ---------------------------------------------------------------------------
+// Regression: 401 on bootstrap must redirect, not spin forever
+// ---------------------------------------------------------------------------
+
+test.describe('Auth failure — 401 from /me redirects to /signin', () => {
+
+  test('redirects to /signin on bootstrap 401 (regression: was infinite spinner)', async ({
+    adminAuthenticatedPage: page,
+  }) => {
+    // Intercept all /me calls from this point on to return 401.
+    await page.route(ME_URL, (route: Route) => route.fulfill(ME_401_RESPONSE));
+    await clearMeCache(page);
+
+    // Reload simulates the "backend DB swapped, user no longer exists" scenario.
+    // The token in localStorage is still valid locally; the server will reject it.
+    await page.reload({ waitUntil: 'domcontentloaded' });
+
+    // Must redirect to /signin — NOT remain on spinner for 5 minutes.
+    await page.waitForURL('**/signin', { timeout: 10_000 });
+    await expect(page).toHaveURL(/\/signin/);
+  });
+
+  test('redirect resolves in well under 5 seconds (not the old 5-minute timeout)', async ({
+    adminAuthenticatedPage: page,
+  }) => {
+    await page.route(ME_URL, (route: Route) => route.fulfill(ME_401_RESPONSE));
+    await clearMeCache(page);
+
+    const start = Date.now();
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForURL('**/signin', { timeout: 10_000 });
+
+    const elapsed = Date.now() - start;
+    // The old behaviour timed out after 5 × 60 × 1000 ms = 300 000 ms.
+    // A correct implementation must redirect in a fraction of that.
+    expect(elapsed).toBeLessThan(5_000);
+  });
+
+  // -------------------------------------------------------------------------
+  // Deduplication guard
+  // -------------------------------------------------------------------------
+
+  test('navigates to /signin exactly once even when multiple code paths see 401', async ({
+    adminAuthenticatedPage: page,
+  }) => {
+    // Both MeContext.fetchMe() and ProvisioningGuard.initialCheck() may race to
+    // detect the 401. logoutCalledRef must prevent duplicate router.push calls.
+    await page.route(ME_URL, (route: Route) => route.fulfill(ME_401_RESPONSE));
+    await clearMeCache(page);
+
+    let signinNavigations = 0;
+    page.on('framenavigated', (frame: Frame) => {
+      if (frame === page.mainFrame() && frame.url().includes('/signin')) {
+        signinNavigations++;
+      }
+    });
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForURL('**/signin', { timeout: 10_000 });
+
+    // Wait a beat to catch any delayed duplicate navigation.
+    await page.waitForTimeout(1_000);
+
+    expect(signinNavigations).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Logout reason is preserved for the signin page
+  // -------------------------------------------------------------------------
+
+  test('stores a logout reason in sessionStorage so signin page can show a message', async ({
+    adminAuthenticatedPage: page,
+  }) => {
+    await page.route(ME_URL, (route: Route) => route.fulfill(ME_401_RESPONSE));
+    await clearMeCache(page);
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForURL('**/signin', { timeout: 10_000 });
+
+    const reason = await page.evaluate(() => {
+      const raw = sessionStorage.getItem('logoutReason');
+      return raw ? JSON.parse(raw) : null;
+    });
+
+    expect(reason).not.toBeNull();
+    expect(reason.message).toBe('Your session has expired');
+    expect(reason.action).toBe('Please sign in again');
+  });
+
+  // -------------------------------------------------------------------------
+  // No admin content rendered during redirect window (Finding 2 regression)
+  //
+  // ProvisioningGuard.authFailed effect calls setStatus("loading") before
+  // signOut() to ensure <AuthLoader /> is shown — not page children —
+  // during the router.push navigation window.
+  // -------------------------------------------------------------------------
+
+  test('does not render admin content during the redirect window', async ({
+    adminAuthenticatedPage: page,
+  }) => {
+    // Intercept before reload so the very first /me call returns 401.
+    await page.route(ME_URL, (route: Route) => route.fulfill(ME_401_RESPONSE));
+    await clearMeCache(page);
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+
+    // AppSidebar / the main nav lives inside ProvisioningGuard's children.
+    // If status is forced to "loading" before signOut fires, it will never
+    // be painted. We accept a generous 1-second window to catch any flash.
+    const sidebarVisible = await page
+      .locator('aside, [data-testid="app-sidebar"]')
+      .first()
+      .isVisible({ timeout: 1_000 })
+      .catch(() => false);
+
+    expect(sidebarVisible).toBe(false);
+
+    await page.waitForURL('**/signin', { timeout: 10_000 });
+  });
+
+  // -------------------------------------------------------------------------
+  // Token is cleared after auth failure (no stale credential left in storage)
+  // -------------------------------------------------------------------------
+
+  test('clears auth token from storage after 401 redirect', async ({
+    adminAuthenticatedPage: page,
+  }) => {
+    await page.route(ME_URL, (route: Route) => route.fulfill(ME_401_RESPONSE));
+    await clearMeCache(page);
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForURL('**/signin', { timeout: 10_000 });
+
+    const tokenAfter = await page.evaluate(
+      () => localStorage.getItem('token') ?? sessionStorage.getItem('token')
+    );
+
+    // Token must be removed by the canonical logout utility so the next
+    // page load does not attempt to re-use the rejected credential.
+    expect(tokenAfter).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Re-navigation to a protected route after logout shows signin, not spinner
+  // -------------------------------------------------------------------------
+
+  test('navigating to a protected route after 401 logout shows signin form', async ({
+    adminAuthenticatedPage: page,
+  }) => {
+    await page.route(ME_URL, (route: Route) => route.fulfill(ME_401_RESPONSE));
+    await clearMeCache(page);
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForURL('**/signin', { timeout: 10_000 });
+
+    // Stop intercepting /me so it can respond normally.
+    await page.unroute(ME_URL);
+
+    // Navigate back to a protected route without a token.
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    // useAuth finds no token and redirects — must not spin or crash.
+    await expect(page).toHaveURL(/\/signin/);
+    await expect(page.locator('input[type="email"]').first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
MeContext now surfaces authFailed when /me rejects the token (e.g.
after a DB swap invalidates user records). ProvisioningGuard reacts with
a dedicated effect that calls signOut() instead of entering the 5-minute
provisioning retry loop.

Adds logoutCalledRef deduplication to prevent concurrent code paths
(MeContext background fetch + ProvisioningGuard initialCheck/poll) from
issuing multiple router.push('/signin') calls.

Fixes: infinite spinner on locally-valid but server-rejected JWT.