### PR TITLE
Remove deprecated DALL-E models from AI model init

### DIFF
--- a/backend/init/init_ai_models.py
+++ b/backend/init/init_ai_models.py
@@ -221,28 +221,6 @@ AI_MODELS = [
     # ===================== OPENAI – IMAGE =====================
     {
         "service": AiServiceProvider.OPEN_AI,
-        "name": "DALL·E 3",
-        "model_identifier": "dall-e-3",
-        "credits": 400,
-        "input_tokens_cost": 0.04,
-        "output_tokens_cost": 0.08,
-        "completion": False,
-        "embedding": False,
-        "image_completion": False,
-        "image_generation": True,
-        "reasoning": False,
-        "enabled": True,
-        "rank": 20,
-        "params": {
-            "default_resolution": "1024x1024",
-            "supported_resolutions": ["1024x1024", "1792x1024", "1024x1792"],
-            "quality": ["standard", "hd"]
-        },
-        "tier": 5,
-        "icon": ICON_OPENAI,
-    },
-    {
-        "service": AiServiceProvider.OPEN_AI,
         "name": "GPT Image 1",
         "model_identifier": "gpt-image-1",
         "credits": 400,

--- a/docs/docs/development/using-ai-framework.md
+++ b/docs/docs/development/using-ai-framework.md
@@ -62,7 +62,7 @@ For a production non-Atlas setup, **[Milvus](https://milvus.io/)** is the recomm
 
 | Provider | Representative models |
 |---|---|
-| **OpenAI** | GPT-5 series, GPT-4 Turbo, GPT-4o, DALL-E 3, text-embedding-3-* |
+| **OpenAI** | GPT-5 series, GPT-4 Turbo, GPT-4o, GPT Image 1, text-embedding-3-* |
 | **Anthropic (Claude)** | Claude 4 Opus/Sonnet, Claude 3.7 Sonnet |
 | **DeepInfra** | Llama 4, Qwen 3, Mistral, Gemma 3, DeepSeek R2, BAAI embeddings |
 | **Ollama** | Any locally-served model (point `OLLAMA_BASE_URL` at your instance) — see [AI Assistant with Ollama](../getting-started/ollama-local-ai.md) |

--- a/docs/docs/user-guide/ai-models-tiers.md
+++ b/docs/docs/user-guide/ai-models-tiers.md
@@ -103,9 +103,9 @@ Enabled: Yes
 #### For Image Generation Models
 
 ```
-Name: DALL-E 3
+Name: GPT Image 1
 Service Provider: OPEN_AI
-Model Identifier: dall-e-3
+Model Identifier: gpt-image-1
 Image Generation Support: Yes
 Enabled: Yes
 ```


### PR DESCRIPTION
## Summary
- Remove the DALL-E 3 seed entry from `backend/init/init_ai_models.py` (DALL-E 2 was never present in the seed data, so this closes out both models named in the issue)
- Update docs examples in `ai-models-tiers.md` and `using-ai-framework.md` that referenced DALL-E 3 to use GPT Image 1 instead, which covers the same image-generation capability and is already seeded

## Test plan
- [ ] Re-run the seed script (`backend/init/init_ai_models.py`) against a local/test DB and confirm no `dall-e-*` models are inserted
- [ ] Confirm GPT Image 1 still seeds correctly with its existing params

Closes #15